### PR TITLE
Revisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ optional arguments:
 
 --stage, --no-stage : Set if missing devices and signals should be staged and reconnected as they appear during session load, default false
 
---clear, --no-clear : Set if maps should be cleared during session load, default true
+--clear, --no-clear : Set if maps should be cleared during session load, default false
 
 --save PATH : Save session as JSON file
 
@@ -53,19 +53,19 @@ saves the current mapping state as a JSON session file.
 - optional param views: GUI related object for recreating the session
 - return: The session JSON object
 
-`session.load_file(filename, should_stage=False, should_clear=True, in_bg=True)`
+`session.load_file(filename, should_stage=False, should_clear=False, in_bg=True)`
 loads a session file with options for staging and clearing
 - param filename (String): The JSON file to load
 - optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-- optional param should_clear (Boolean): Clear all maps before loading the session, default True
+- optional param should_clear (Boolean): Clear all maps before loading the session, default False
 - optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
 - return (Dict): visual session information relevant to GUIs
 
-`session.load_json(filename, should_stage=False, should_clear=True, in_bg=True)`
+`session.load_json(filename, should_stage=False, should_clear=False, in_bg=True)`
 loads a session JSON Dict with options for staging and clearing
 - param session_json (Dict): A session JSON Dict to load
 - optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-- optional param should_clear (Boolean): Clear all maps before loading the session, default True
+- optional param should_clear (Boolean): Clear all maps before loading the session, default False
 - optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
 - return (Dict): visual session information relevant to GUIs
 

--- a/README.md
+++ b/README.md
@@ -7,19 +7,21 @@ Simply run `pip install mappersession` in your python environment of choice.
 
 ## Usage
 
-### From the command-line
+### Usage from the command-line
 
-usage: [-h] [--load PATH [PATH ...]] [--stage | --no-stage] [--clear | --no-clear]
+usage: [-h] [--load PATH [PATH ...]] [--wait | --no-wait] [--clear | --no-clear]
                    [--save PATH] [--description DESCRIPTION]
 
 optional arguments:
 -h, --help : Show the help message and exit
 
---load PATH [PATH ...] : Session JSON file to load
+--load PATH [PATH ...] : Session JSON file(s) to load
 
---stage, --no-stage : Set if missing devices and signals should be staged and reconnected as they appear during session load, default false
+--unload PATH [PATH ...] : Session JSON file(s) to unload
 
---clear, --no-clear : Set if maps should be cleared during session load, default false
+--wait, --no-wait : Set if session should wait for missing devices and signals and connected them as they appear during session load, default False
+
+--clear, --no-clear : Set if maps should be cleared after saving and/or before load, default false
 
 --save PATH : Save session as JSON file
 
@@ -27,51 +29,95 @@ optional arguments:
 
 Examples:
 
-Load a session, clear all maps and handle staging of missing connections:
+Clear all active maps, load a session file and wait for needed signals to appear:
 
-`python -m mappersession --load mysession.json --clear --stage`
+```
+python -m mappersession --load mysession.json --clear --wait
+```
+
+Unload a session file:
+
+```
+python -m mappersession --unload mysession.json
+```
+
+Start an interactive session with libmapper control signals for loading/unloading each file:
+
+```
+python -m mappersession --load session1.json session2.json --interactive
+```
 
 Save the current session and provide a description:
 
-`python -m mappersession --save mysession.json --description "This session does something cool"`
+```
+python -m mappersession --save mysession.json --description "This session does something cool"
+```
 
-### As a module
+### Usage as a Python module
 
-Import the module:
+#### Importing the module
 
-`import mappersession as session`
+```
+import mappersession as session
+```
 
-Then call save/load functions with function structures detailed below:
+#### Saving a mapping session file
 
-`session.save(filename="", description="", values=[], viewName="", views=[])`
+```
+session.save(filename="", description="", values=[],
+             viewName="", views=[], graph=None)
+```
 
-saves the current mapping state as a JSON session file.    
-- optional param filename: The JSON file to save the session into 
-- optional param description: A short description of the current session
-- optional param values: Array of {name, value} pairs for signals to set on session load
-- optional param viewName: Name of the GUI that's adding metadata
-- optional param views: GUI related object for recreating the session
+- param `filename`: The name of the file to save
+- optional param `description`: A short description of the current session
+- optional param `values`: Array of {name, value} pairs for signals to set on session load
+- optional param `viewName`: Name of the GUI that's adding metadata
+- optional param `views`: GUI related object for recreating the session
+- optional param `graph`: A previously-allocated libmapper Graph object to use. If not provided one will be allocated internally.
 - return: The session JSON object
 
-`session.load_file(filename, should_stage=False, should_clear=False, in_bg=True)`
-loads a session file with options for staging and clearing
-- param filename (String): The JSON file to load
-- optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-- optional param should_clear (Boolean): Clear all maps before loading the session, default False
-- optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
+#### Loading a mapping session file
+
+```
+session.load(filename, interactive=False, wait=False, persist=False, background=False, device_map=None, graph=None)
+```
+
+loads session files and optionally waits for signals. Maps will be tagged with the filename using a property named `session`.
+
+- param `filename` (String or List): The session file(s) to load
+- optional param `interactive` (Boolean): Starts an interactive session for managing multiple session files. A libmapper control signal is created for corresponding to each file; setting the control signal value to a non-zero value loads the file, and setting it to zero unloads the file.
+- optional param `wait` (Boolean): Wait for missing signals during session load and create maps once they appear, default `False`
+- optional param `persist` (Boolean): Continue running after creating maps in session, and recreate them as matching signals (re)appear, default False
+- optional param `background` (Boolean): True if waiting for signals should happen in a background thread, default False
+- optional param `device_map` (Dict): A dictionary specifying correspondences between device names stored in a session file and names of devices active on the network.
+- optional param `graph`: A previously-allocated libmapper Graph object to use. If not provided one will be allocated internally.
 - return (Dict): visual session information relevant to GUIs
 
-`session.load_json(filename, should_stage=False, should_clear=False, in_bg=True)`
+#### Unloading a mapping session file
+
+```
+session.unload(filename, graph=None)
+```
+
+loads session files and optionally waits for signals. Maps will be tagged with the filename using a property named `session`.
+
+- param `filename` (String or List): The session file(s) to unload
+- optional param `graph`: A previously-allocated libmapper Graph object to use. If not provided one will be allocated internally.
+- return (None)
+
+#### Loading JSON-formatted session data
+
+```
+session.load_json(session_json, name=None, wait=False, persist=False, background=False, device_map=None, graph=None)
+```
+
 loads a session JSON Dict with options for staging and clearing
-- param session_json (Dict): A session JSON Dict to load
-- optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-- optional param should_clear (Boolean): Clear all maps before loading the session, default False
-- optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
-- return (Dict): visual session information relevant to GUIs
 
-`session.cycle_files(filenames)`
-manages cycling through multiple session files. A libmapper signal is created
-that changes which session is currently active, or users can use the left/right
-arrow keys to change sessions.
-- param filenames (String): The JSON files to load (1st is loaded immediately)
-- return (None): Blocks while executing, should CTL+C or hit 'e' to exit
+- param session_json (Dict): A session JSON Dict to load
+- optional param `name` (String): A name for the session; any maps created by this session will be tagged with the name.
+- optional param `wait` (Boolean): Wait for missing signals during session load and create maps once they appear, default `False`
+- optional param `persist` (Boolean): Continue running after creating maps in session, and recreate them as matching signals (re)appear, default False
+- optional param `background` (Boolean): True if waiting for signals should happen in a background thread, default False
+- optional param `device_map` (Dict): A dictionary specifying correspondences between device names stored in a session file and names of devices active on the network.
+- optional param `graph`: A previously-allocated libmapper graph object to use. If not provided one will be allocated internally.
+- return (Dict): visual session information relevant to GUIs

--- a/src/mappersession/__init__.py
+++ b/src/mappersession/__init__.py
@@ -1,1 +1,1 @@
-from .mappersession import save, load_file, cycle_files, load_json, clear
+from .mappersession import save, load, unload, load_json, clear

--- a/src/mappersession/__main__.py
+++ b/src/mappersession/__main__.py
@@ -7,17 +7,28 @@ def createParser():
         '--load', type=argparse.FileType('r'),
         nargs='+',
         metavar='PATH',
-        help="Session JSON file(s) to load")
+        help="Mapping session file(s) to load")
     parser.add_argument(
-        '--stage', action=argparse.BooleanOptionalAction,
-        help="Set if missing devices and signals should be staged and reconnected as they appear during session load")
-    parser.add_argument(
-        '--clear', action=argparse.BooleanOptionalAction,
-        help="Set if maps should be cleared during session load, or --no-clear to leave maps")
+        '--unload', type=argparse.FileType('r'),
+        nargs='+',
+        metavar='PATH',
+        help="Mapping session file(s) to unload")
     parser.add_argument(
         '--save', type=ascii,
         metavar='PATH',
-        help="Save session as JSON file")
+        help="Save mapping session as JSON file")
+    parser.add_argument(
+        '--clear', action=argparse.BooleanOptionalAction,
+        help="Clear currently active maps")
+    parser.add_argument(
+        '--wait', action=argparse.BooleanOptionalAction,
+        help="Wait for missing signals during session load and create maps once they appear.")
+    parser.add_argument(
+        '--persist', action=argparse.BooleanOptionalAction,
+        help="Remain active during session load and (re)create maps as they appear.")
+    parser.add_argument(
+        '--interactive', action=argparse.BooleanOptionalAction,
+        help="Create libmapper signals for managing file loading and unloading.")
     parser.add_argument(
         '--description', type=ascii,
         help="Description of session, used when saving")
@@ -27,21 +38,35 @@ def createParser():
     return parser
 
 if __name__ == '__main__':
-    import mappersession as session
+    try:
+        import mappersession as session
+    except:
+        try:
+            sys.path.append(
+                            os.path.join(os.path.join(os.getcwd(),
+                                                      os.path.dirname(sys.argv[0])),
+                                         './mappersession'))
+            import mappersession as session
+        except:
+            print('Error importing mappersession module.')
+            sys.exit(1)
+
     # Parse arguments
     parser = createParser()
     args = parser.parse_args()
+    should_clear = args.clear if args.clear != None else False
+
     if (args.save is not None):
         session.save(args.save, args.description if args.description != None else "")
-    elif (args.load is not None):
-        should_stage = args.stage if args.stage != None else False
-        should_clear = args.clear if args.clear != None else False
-        if len(args.load) > 1:
-            filenames = [path.name for path in args.load]
-            session.cycle_files(filenames)
-        else:
-            session.load_file(args.load[0].name, should_stage, should_clear, False)
-    elif (args.clear is not None):
+    if should_clear:
+        # clear after save and before load
         session.clear()
-    else:
-        print("Not enough arguments provided, please use --save or --load with JSON file path(s)")
+    elif (args.unload is not None):
+        filenames = [path.name for path in args.unload]
+        session.unload(filenames)
+    if (args.load is not None):
+        interactive = args.interactive if args.interactive != None else False
+        wait = args.wait if args.wait != None else False
+        persist = args.persist if args.persist != None else False
+        filenames = [path.name for path in args.load]
+        session.load(filenames, interactive=interactive, wait=wait, persist=persist)

--- a/src/mappersession/__main__.py
+++ b/src/mappersession/__main__.py
@@ -35,7 +35,7 @@ if __name__ == '__main__':
         session.save(args.save, args.description if args.description != None else "")
     elif (args.load is not None):
         should_stage = args.stage if args.stage != None else False
-        should_clear = args.clear if args.clear != None else True
+        should_clear = args.clear if args.clear != None else False
         if len(args.load) > 1:
             filenames = [path.name for path in args.load]
             session.cycle_files(filenames)

--- a/src/mappersession/mappersession.py
+++ b/src/mappersession/mappersession.py
@@ -10,26 +10,47 @@ if platform.system() == 'Windows':
     import msvcrt
 else:
     import select
+import itertools, signal
 
 current_fileversion = "2.4"
-g = mpr.Graph()
+g = None
 staging_thread = None
-kill_staging = False
-# Bookkeeping for maps
-connected_maps = []
-staged_maps = []
-# Session cycling files
-cur_session_idx = 0
-session_cycling_filenames = []
+stop_session = False
 
-def save(filename="", description="", values=[], view_name="", views=[]):
+# Bookkeeping for maps
+staged_maps = []
+# Session files
+session_filenames = []
+
+def handler_stop_session(signum, frame):
+    global stop_session
+    stop_session = True
+    if staging_thread != None:
+        staging_thread.stop()
+
+signal.signal(signal.SIGINT, handler_stop_session)
+signal.signal(signal.SIGTERM, handler_stop_session)
+
+def check_graph(graph, sync=True):
+    global g
+    if not graph:
+        g = mpr.Graph()
+        if sync:
+            print('syncing graph...')
+            g.poll(2000)
+    else:
+        g = graph
+    return g
+
+def save(filename="", description="", values=[], view_name="", views=[], graph=None):
     """saves the current mapping state as a JSON session file.
-    
+
     :optional param filename (String): The JSON file to save the session into
     :optional param description (String): A short description of the current session
     :optional param values (List): Array of signal {name, value} pairs to set on session load
     :optional param view_name (String): Name of the GUI that's adding metadata
     :optional param views (List): GUI related object for recreating the session
+    :optional param graph (libmapper Graph object): A previously-allocated libmapper graph object to use. If not provided one will be allocated internally.
     :return (Dict): The session JSON object
     """
 
@@ -40,39 +61,36 @@ def save(filename="", description="", values=[], view_name="", views=[]):
     session["values"] = values
     session["views"] = views
 
+    graph = check_graph(graph)
+
     # Populate maps
-    g = mpr.Graph()
     print("Collecting maps from network...")
-    g.poll(1000)
     session["maps"] = []
-    for mapIdx in range(len(g.maps())):
+    for map in graph.maps():
+
+        # omit 'hidden' devices
+        if any([sig.device()["hidden"] for sig in map.signals()]):
+            print("Skipping hidden device")
+            continue
+
         newMap = {}
         # Source signals
-        srcSigs = g.maps()[mapIdx].signals(mpr.Location.SOURCE)
-        newMap["sources"] = []
-        for srcIdx in range(len(srcSigs)):
-            srcName = (srcSigs[srcIdx].device()[mpr.Property.NAME] +
-                        "/" + srcSigs[srcIdx][mpr.Property.NAME])
-            newMap["sources"].append(srcName)
+        newMap["sources"] = [(sig.device()[mpr.Property.NAME] + "/" + sig[mpr.Property.NAME])
+                             for sig in map.signals(mpr.Location.SOURCE)]
+
         # Destination signals
-        dstSigs = g.maps()[mapIdx].signals(mpr.Location.DESTINATION)
-        newMap["destinations"] = []
-        for dstIdx in range(len(dstSigs)):
-            dstName = (dstSigs[dstIdx].device()[mpr.Property.NAME] +
-                        "/" + dstSigs[dstIdx][mpr.Property.NAME])
-            newMap["destinations"].append(dstName)
+        newMap["destinations"] = [(sig.device()[mpr.Property.NAME] + "/" + sig[mpr.Property.NAME])
+                                  for sig in map.signals(mpr.Location.DESTINATION)]
 
         # Other properties
-        newMap["expression"] = g.maps()[mapIdx][mpr.Property.EXPRESSION]
-        newMap["muted"] = g.maps()[mapIdx][mpr.Property.MUTED]
-        newMap["process_loc"] = mpr.Location(g.maps()[mapIdx][mpr.Property.PROCESS_LOCATION]).name
-        newMap["protocol"] = g.maps()[mapIdx][mpr.Property.PROTOCOL].name
-        newMap["scope"] = []
-        scopeDevs = g.maps()[mapIdx][mpr.Property.SCOPE]
-        for devIdx in range(len(scopeDevs)):
-            newMap["scope"].append(scopeDevs[devIdx][mpr.Property.NAME])
-        newMap["use_inst"] = g.maps()[mapIdx][mpr.Property.USE_INSTANCES]
-        newMap["version"] = g.maps()[mapIdx][mpr.Property.VERSION]
+        # TODO: need to save ALL map properties!
+        newMap["expression"] = map[mpr.Property.EXPRESSION]
+        newMap["muted"] = map[mpr.Property.MUTED]
+        newMap["process_loc"] = map[mpr.Property.PROCESS_LOCATION].name
+        newMap["protocol"] = map[mpr.Property.PROTOCOL].name
+        newMap["scope"] = [dev[mpr.Property.NAME] for dev in map[mpr.Property.SCOPE]]
+        newMap["use_inst"] = map[mpr.Property.USE_INSTANCES]
+        newMap["version"] = map[mpr.Property.VERSION]
 
         # Add to maps
         session["maps"].append(newMap)
@@ -86,142 +104,163 @@ def save(filename="", description="", values=[], view_name="", views=[]):
 
 # Internal staging method to be used in a thread
 # maps that should be staged should be added to the global 'staged_maps'
-def stage():
-    global kill_staging, staged_maps, connected_maps
-    kill_staging = False
-    print("Starting session staging")
-    while True:
-        if kill_staging:
-            print("Ending session staging")
-            break
-        else:
-            g.poll(100)
-            # Re-stage any missing "connected" maps
-            for connected_map in connected_maps:
-                found_map = find_map(connected_map["sources"], connected_map["destinations"][0])
-                if not found_map:
-                    print("map re-staged: ", connected_map["sources"], "->", connected_map["destinations"])
-                    staged_maps.append(connected_map.copy())
-                    connected_maps.remove(connected_map)
-            # Try to create any staged maps that we can
-            try:
-                new_maps = try_make_maps(staged_maps)
+def wait_for_sigs(persist=False):
+    global g, staged_maps
+
+    while not stop_session and (len(staged_maps) or persist):
+        # Try to create any staged maps that we can
+        try:
+            # TODO: don't bother running this unless new devices have appeared
+            g.poll(1000)
+            new_maps = try_make_maps(g, staged_maps, None)
+            if not persist:
                 for new_map in new_maps:
-                    connected_maps.append(new_map.copy())
                     staged_maps.remove(new_map)
-            except:
-                pass
+        except:
+            pass
 
 # Attempts to create any eligible maps that have all sources and destination present 
-def try_make_maps(maps):
+def try_make_maps(graph, maps, device_map=None):
+
     new_maps = []
     for map in maps:
         # Check if the map's signals are available
-        srcs = [find_sig(k) for k in map["sources"]]
-        dst = find_sig(map["destinations"][0])
-        if all(srcs) and dst:
-            # Create map and remove from staged list
-            new_map = mpr.Map(srcs, dst)
-            if not new_map:
-                print('error: failed to create map', map["sources"], "->", map["destinations"])
-                continue
-            print('created map: ', map["sources"], "->", map["destinations"])
-            # Set map properties
-            new_map[mpr.Property.EXPRESSION] = map["expression"]
-            new_map[mpr.Property.MUTED] = map["muted"]
-            if map["process_loc"] == 'SOURCE':
-                new_map[mpr.Property.PROCESS_LOCATION] = mpr.Location.SOURCE
-            elif map["process_loc"] == 'DESTINATION':
-                new_map[mpr.Property.PROCESS_LOCATION] = mpr.Location.DESTINATION
-            new_map[mpr.Property.PROCESS_LOCATION] = map["process_loc"]
-            if map["protocol"] == 'udp' or map["protocol"] == 'UDP':
-                new_map[mpr.Property.PROTOCOL] = mpr.Protocol.UDP
-            elif map["protocol"] == 'tcp' or map["protocol"] == 'TCP':
-                new_map[mpr.Property.PROTOCOL] = mpr.Protocol.TCP
-            # new_map[mpr.Property.SCOPE] = map["scope"]
-            new_map[mpr.Property.USE_INSTANCES] = map["use_inst"]
-            new_map[mpr.Property.VERSION] = map["version"]
-            # Push to network
-            new_map.push()
-            new_maps.append(map.copy())
+        # Match signals with different device names for mapping transportability
+        
+        srcs = [find_sigs(graph, s, device_map) for s in map["sources"]]
+        dsts = find_sigs(graph, map["destinations"][0], device_map)
+
+        for d in dsts:
+            for s in list(itertools.product(*srcs)):
+                # Create map and remove from staged list
+                new_map = mpr.Map(list(s), d)
+                if not new_map:
+                    print('error: failed to create map', map["sources"], "->", map["destinations"])
+                    continue
+                print('created map: ', map["sources"], "->", map["destinations"])
+
+                # Set map properties
+                # TODO: need to iterate through ALL properties!
+
+                new_map[mpr.Property.EXPRESSION] = map["expression"]
+                new_map[mpr.Property.MUTED] = map["muted"]
+                if map["process_loc"] == 'SOURCE':
+                    new_map[mpr.Property.PROCESS_LOCATION] = mpr.Location.SOURCE
+                elif map["process_loc"] == 'DESTINATION':
+                    new_map[mpr.Property.PROCESS_LOCATION] = mpr.Location.DESTINATION
+                new_map[mpr.Property.PROCESS_LOCATION] = map["process_loc"]
+                if map["protocol"] == 'udp' or map["protocol"] == 'UDP':
+                    new_map[mpr.Property.PROTOCOL] = mpr.Protocol.UDP
+                elif map["protocol"] == 'tcp' or map["protocol"] == 'TCP':
+                    new_map[mpr.Property.PROTOCOL] = mpr.Protocol.TCP
+                # TODO: map scope property may need to be translated
+                # new_map[mpr.Property.SCOPE] = map["scope"]
+                new_map[mpr.Property.USE_INSTANCES] = map["use_inst"]
+                new_map[mpr.Property.VERSION] = map["version"]
+
+                # TODO: session property should be an array
+                if 'session' in map:
+                    new_map['session'] = map['session']
+
+                # Push to network
+                new_map.push()
+                new_maps.append(map.copy())
+    graph.poll()
     return new_maps
 
-def cycle_files(filenames):
-    """manages cycling through multiple session files. A libmapper signal is created
-    that changes which session is currently active, or users can use the left/right
-    arrow keys to change sessions.
+def start_session(graph, filenames):
+    """start an interactive session. A libmapper signal is created for loading/unloading each file.
     
-    :param filenames (String): The JSON files to load (1st is loaded immediately)
+    :param filenames (String or List): The JSON files to load
     :return (None): Blocks while executing, should CTL+C or hit 'e' to exit
     """
 
-    global session_cycling_filenames, cur_session_idx
+    graph = check_graph(graph, sync=False)
 
-    cur_session_idx = 0
-    session_cycling_filenames = filenames
-
-    # Load first session file
-    load_file(filenames[0], True)
+    global session_filenames, stop_session
+    session_filenames = filenames
 
     # Set up libmapper signal that controls the current session index
-    dev = mpr.Device("mappersession")
-    sig_cur_session = dev.add_signal(mpr.Direction.INCOMING, "cur_session_idx", 1,
-                        mpr.Type.INT32, "", 0, len(filenames), None, cur_session_handler)
+    dev = mpr.Device("mappersession", graph)
+    for filename in session_filenames:
+        signame = filename.removesuffix(".json").split('/')[-1]
+        # TODO: need to handle duplicate filenames?
+        sig = dev.add_signal(mpr.Direction.INCOMING, signame, 1, mpr.Type.INT32,
+                             None, 0, 1, None, cur_session_handler)
+        sig.set_property("filename", filename, publish=False)
 
-    while (True):
+    while (not stop_session):
         dev.poll(50)
 
+    dev.free()
+    if graph is not None:
+        graph.free()
+
 def cur_session_handler(sig, event, id, val, timetag):
-    global session_cycling_filenames, cur_session_idx
+    global session_filenames
     try:
         if event == mpr.Signal.Event.UPDATE:
-            new_idx = session_cycling_filenames[val % len(session_cycling_filenames)]
-            if new_idx != cur_session_idx:
-                load_file(new_idx, True)
-                cur_session_idx = new_idx
-                print("Changed session to: ", new_session)
+            filename = sig['filename']
+            if val == 0:
+                print('unloading', filename)
+                unload(filename, graph = sig.graph())
+            else:
+                print('loading', filename)
+                load(filename, graph = sig.graph())
     except:
         print('exception')
         print(sig, val)
 
-def handle_cycling_inputs():
-    # TODO: get keyboard input for (h)elp, <-, ->, (e)xit
-    if platform.system() == 'Windows':
-        pass
-    else:
-        pass
+def load(filename, interactive=False, wait=False, persist=False, background=False, device_map=None, graph=None):
+    """loads a session file with options for staging
 
-def load_file(filename, should_stage=False, should_clear=False, in_bg=True):
-    """loads a session file with options for staging and clearing
-    
-    :param filename (String): The JSON file to load
-    :optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-    :optional param should_clear (Boolean): Clear all maps before loading the session, default False
-    :optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
+    :param filenames (String or List): The JSON file(s) to load
+    :optional param interactive (Boolean): Create libmapper signals for controlling session loading/unloading, default False
+    :optional param wait (Boolean): Wait for missing signals and create maps when they appear, default False
+    :optional param persist (Boolean): Continue running after creating maps in session, and recreate them as matching signals (re)appear, default False
+    :optional param background (Boolean): Wait for missing signals in a background thread, default True
+    :optional param graph (libmapper Graph object): A previously-allocated libmapper graph object to use. If not provided one will be allocated internally.
     :return (Dict): visual session information relevant to GUIs
     """
 
-    # Parse session file
-    file = open(filename)
-    data = json.load(file)
-    # Load session
-    views = load_json(data, should_stage, should_clear, in_bg)
+    if interactive:
+        return start_session(graph, filename)
+
+    if not isinstance(filename, list):
+        filename = [filename]
+    views = []
+
+    for name in filename:
+        # Parse session file
+        file = open(name)
+        data = json.load(file)
+        # Load session
+        views.extend(load_json(data, name, wait, persist, background, device_map, graph))
     return views
 
-def load_json(session_json, should_stage=False, should_clear=False, in_bg=True):
-    """loads a session JSON Dict with options for staging and clearing
-    
+def load_json(session_json, name=None, wait=False, persist=False, background=False, device_map=None, graph=None):
+    """loads a session JSON Dict with options for staging
+
     :param session_json (Dict): A session JSON Dict to load
-    :optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-    :optional param should_clear (Boolean): Clear all maps before loading the session, default False
-    :optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
+    :optional param name (String): Tag for maps created for this session
+    :optional param wait (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default False
+    :optional param persist (Boolean): Continue running after creating maps in session, and recreate them as matching signals (re)appear, default False
+    :optional param background (Boolean): True if any staging should happen in a background thread, default True
+    :optional param graph (libmapper Graph object): A previously-allocated libmapper graph object to use. If not provided one will be allocated internally.
     :return (Dict): visual session information relevant to GUIs
     """
 
-    global g, staging_thread, staged_maps, current_fileversion
+    global staging_thread, staged_maps, current_fileversion
+
+    graph = check_graph(graph)
 
     # Update json if fileversion doesn't match current schema
     session_json = upgrade_json(session_json)
+
+    if 'maps' in session_json and name is not None:
+        name = name.removesuffix(".json").split('/')[-1]
+        for map in session_json['maps']:
+            map['session'] = name
 
     # Validate session according to schema
     schemaData = pkgutil.get_data(__name__, "mappingSessionSchema.json")
@@ -232,42 +271,57 @@ def load_json(session_json, should_stage=False, should_clear=False, in_bg=True):
         print(err)
         return None
 
-    # Clear current session if requested
-    if should_clear:
-        clear()
-
-    if should_stage:
+    if wait or persist:
         staged_maps.extend(session_json["maps"])
         if staging_thread == None:
-            if in_bg:
-                staging_thread = threading.Thread(target = stage, daemon = True)
+            if background:
+                staging_thread = threading.Thread(target = wait_for_sigs, daemon = True)
                 staging_thread.start()
             else:
-                stage()
+                wait_for_sigs(persist)
     else:
-        # Try twice to make maps (sometimes doesn't get them all on the first pass for some reason)
-        g.poll(50)
-        new_maps = try_make_maps(session_json["maps"])
-        g.poll(50)
-        session_json["maps"] = [x for x in session_json["maps"] if x not in new_maps]
-        try_make_maps(session_json["maps"])
+        new_maps = try_make_maps(graph, session_json["maps"], device_map)
 
     return session_json["views"]
 
-def clear():
-    """clears all maps on the network except for connections to mappersession
+def unload(filename, graph=None):
+    """unloads session files
+
+    :param filename (String or List): The JSON file(s) to unload
+    :optional param graph (libmapper Graph object)
     """
-    global g, staged_maps, connected_maps
-    staged_maps = []
-    connected_maps = []
-    g.poll(50)
-    for map in g.maps():
+
+    # for now we will just clear maps with matching session tags
+    # TODO: restore maps that belong to other loaded sessions
+
+    graph = check_graph(graph)
+
+    if not isinstance(filename, list):
+        filename = [filename]
+
+    for name in filename:
+        name = name.removesuffix(".json").split('/')[-1]
+        print("unloading session tag", name)
+        clear(name, graph)
+
+def clear(tag=None, graph=None):
+    """clears maps on the network except for those connected to mappersession
+    """
+
+    graph = check_graph(graph)
+
+    maps = graph.maps()
+    if tag:
+        maps = maps.filter('session', tag)
+    for map in maps:
         dstSigs = map.signals(mpr.Location.DESTINATION)
         # Only remove if mappersession isn't the destination
-        if "mappersession" not in dstSigs[0].device()[mpr.Property.NAME]:
-            map.release()
-            map.push()
-    g.poll(50)
+        if "mappersession" in dstSigs[0].device()[mpr.Property.NAME]:
+            continue
+        print("  unloading map:", [s for s in map.signals(mpr.Location.SOURCE)],
+              "->", [s for s in map.signals(mpr.Location.DESTINATION)])
+        map.release()
+    graph.poll()
 
 def get_views(file, view_name):
     """retrieves view-related GUI parameters from a session json file
@@ -319,6 +373,7 @@ def upgrade_json(session_json):
             dstName = dst[1:] if version <= 2.2 else dst["name"]
             newMap["destinations"].append(dstName)
         # Add other fields
+        # TODO: need to iterate through ALL properties!
         # Fix expressions that use legacy signal identifiers
         newExp = map["expression"].replace("src[0]", "x").replace("src", "x")\
                                   .replace("dest[0]", "y").replace("dest", "y")\
@@ -360,32 +415,27 @@ def upgrade_json(session_json):
     session_json["fileversion"] = current_fileversion # Not really necessary I suppose
     return session_json
 
-def find_sig(fullname):
-    global g
+def find_sigs(graph, fullname, device_map=None):
     names = fullname.split('/', 1)
-    dev = g.devices().filter(mpr.Property.NAME, names[0])
-    if dev:
-        sig = dev.next().signals().filter(mpr.Property.NAME, names[1])
-        if not sig:
-            return None
-        return sig.next()
-    else:
-        return None
 
-def find_map(srckeys, dstkey):
-    srcs = [find_sig(k) for k in srckeys]
-    dst = find_sig(dstkey)
-    if not (all(srcs) and dst):
-        return None
-    intersect = dst.maps()
-    for s in srcs:
-        intersect = intersect.intersect(s.maps())
-    for m in intersect:
-        match = True
-        match = match and (m.index(dst) >= 0)
-        if match:
-            for s in srcs:
-                match = match and (m.index(s) >= 0)
-        if match:
-            return m
-    return None
+    '''
+    If device_map dictionary is provided we will attempt to match the exact device name,
+    otherwise we substitute a wildcard for the ordinal and return an array of all matching signals
+    '''
+
+    ret = []
+
+    if device_map and names[0] in device_map:
+        names[0] = device_map[names[0]]
+        print("searching for exact match with device:signal name '{0}:{1}'".format(names[0], names[1]))
+        dev = graph.devices().filter(mpr.Property.NAME, names[0])
+        if dev:
+            sig = dev.next().signals().filter(mpr.Property.NAME, names[1])
+            if sig:
+                ret = [sig.next()]
+    else:
+        print("searching for wildcard match with device:signal name '*:{0}'".format(names[1]))
+        sigs = graph.signals().filter(mpr.Property.NAME, names[1])
+        for sig in sigs:
+            ret.append(sig)
+    return ret

--- a/src/mappersession/mappersession.py
+++ b/src/mappersession/mappersession.py
@@ -429,7 +429,7 @@ def find_sigs(graph, fullname, device_map=None):
         names[0] = device_map[names[0]]
         print("searching for exact match with device:signal name '{0}:{1}'".format(names[0], names[1]))
         dev = graph.devices().filter(mpr.Property.NAME, names[0])
-        if dev:
+        if dev and not dev['hidden']:
             sig = dev.next().signals().filter(mpr.Property.NAME, names[1])
             if sig:
                 ret = [sig.next()]
@@ -437,5 +437,7 @@ def find_sigs(graph, fullname, device_map=None):
         print("searching for wildcard match with device:signal name '*:{0}'".format(names[1]))
         sigs = graph.signals().filter(mpr.Property.NAME, names[1])
         for sig in sigs:
-            ret.append(sig)
+            if not sig.device()['hidden']:
+                ret.append(sig)
+
     return ret

--- a/src/mappersession/mappersession.py
+++ b/src/mappersession/mappersession.py
@@ -298,7 +298,7 @@ def upgrade_json(session_json):
     session_json["description"] = ""
     session_json["views"] = [] # Unable to use legacy views, some fields are not present
     session_json["values"] = []
-    maps = session_json["mapping"]["connections"] if version <= 2.1 else session_json["mapping"]["maps"]
+    maps = session_json["mapping"]["connections"] if version <= 2.1 else session_json["mapping"]["maps"] if version <= 2.3 else session_json["maps"]
 
     for map in maps:
         newMap = {"sources": [], "destinations": []}
@@ -354,8 +354,9 @@ def upgrade_json(session_json):
             newMap["use_inst"] = map["use_inst"]
             newMap["version"] = map["version"]
         session_json["maps"].append(newMap)
-    
-    del session_json["mapping"]
+
+    if "mapping" in session_json:
+        del session_json["mapping"]
     session_json["fileversion"] = current_fileversion # Not really necessary I suppose
     return session_json
 

--- a/src/mappersession/mappersession.py
+++ b/src/mappersession/mappersession.py
@@ -191,12 +191,12 @@ def handle_cycling_inputs():
     else:
         pass
 
-def load_file(filename, should_stage=False, should_clear=True, in_bg=True):
+def load_file(filename, should_stage=False, should_clear=False, in_bg=True):
     """loads a session file with options for staging and clearing
     
     :param filename (String): The JSON file to load
     :optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-    :optional param should_clear (Boolean): Clear all maps before loading the session, default True
+    :optional param should_clear (Boolean): Clear all maps before loading the session, default False
     :optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
     :return (Dict): visual session information relevant to GUIs
     """
@@ -208,12 +208,12 @@ def load_file(filename, should_stage=False, should_clear=True, in_bg=True):
     views = load_json(data, should_stage, should_clear, in_bg)
     return views
 
-def load_json(session_json, should_stage=False, should_clear=True, in_bg=True):
+def load_json(session_json, should_stage=False, should_clear=False, in_bg=True):
     """loads a session JSON Dict with options for staging and clearing
     
     :param session_json (Dict): A session JSON Dict to load
     :optional param should_stage (Boolean): Manages continuous staging and reconnecting of missing devices and signals as they appear, default false
-    :optional param should_clear (Boolean): Clear all maps before loading the session, default True
+    :optional param should_clear (Boolean): Clear all maps before loading the session, default False
     :optional param in_bg (Boolean): True if any staging should happen in a background thread, default True 
     :return (Dict): visual session information relevant to GUIs
     """

--- a/tests/legacy_2-3.json
+++ b/tests/legacy_2-3.json
@@ -47,7 +47,8 @@
 				"var@m": 1,
 				"var@sMax": 127,
 				"var@sMin": 0,
-				"var@sRange": 127
+				"var@sRange": 127,
+				"arbitrary_property": true
 			}
 		]
 	},

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1,7 +1,20 @@
-import mappersession as session
 import libmapper as mpr
 import json
 import os
+import sys
+
+try:
+    import mappersession as session
+except:
+    try:
+        sys.path.append(
+                        os.path.join(os.path.join(os.getcwd(),
+                                                  os.path.dirname(sys.argv[0])),
+                                     '../src/mappersession'))
+        import mappersession as session
+    except:
+        print('Error importing mappersession module.')
+        sys.exit(1)
 
 # An end-to-end test case for saving, loading and clearing sessions
 if __name__ == '__main__':

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -18,17 +18,17 @@ except:
 
 # An end-to-end test case for saving, loading and clearing sessions
 if __name__ == '__main__':
-    g = mpr.Graph()
-    g.poll(100)
+    graph = mpr.Graph()
+    graph.poll(100)
 
     # Load a test session
-    session.load_file("test_session.json")
+    session.load("test_session.json", graph=graph)
 
     # Wait a few seconds for graph to update
-    g.poll(2000)
+    graph.poll(2000)
 
     # Save the session
-    session.save("test_session_saved.json", "A simple test session")
+    session.save("test_session_saved.json", "A simple test session", graph=graph)
 
     # Check that the session files are identical
     og_file = open("test_session.json")
@@ -46,3 +46,5 @@ if __name__ == '__main__':
     os.remove("test_session_saved.json")
 
     print("Test complete")
+
+    graph.free()

--- a/tests/test_legacy_loading.py
+++ b/tests/test_legacy_loading.py
@@ -17,9 +17,9 @@ except:
 if __name__ == '__main__':
 
     # Load a series of legacy files
-    session.load_file("legacy_2-0.json")
-    session.load_file("legacy_2-1.json")
-    session.load_file("legacy_2-2.json")
-    session.load_file("legacy_2-3.json")
+    session.load("legacy_2-0.json")
+    session.load("legacy_2-1.json")
+    session.load("legacy_2-2.json")
+    session.load("legacy_2-3.json")
 
     print("Test complete")

--- a/tests/test_legacy_loading.py
+++ b/tests/test_legacy_loading.py
@@ -1,5 +1,17 @@
-import mappersession as session
-import os
+import os, sys
+
+try:
+    import mappersession as session
+except:
+    try:
+        sys.path.append(
+                        os.path.join(os.path.join(os.getcwd(),
+                                                  os.path.dirname(sys.argv[0])),
+                                     '../src/mappersession'))
+        import mappersession as session
+    except:
+        print('Error importing mappersession module.')
+        sys.exit(1)
 
 # An end-to-end test case for saving, loading and clearing sessions
 if __name__ == '__main__':

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,15 +1,29 @@
 import libmapper as mpr
-import os
+import os, signal
+
+done = False
+
+def handler_done(signum, frame):
+    global done
+    print('signal received, quitting...')
+    done = True
 
 # An end-to-end test case for saving, loading and clearing sessions
 if __name__ == '__main__':
-    dev = mpr.Device("DummyDevice")
+    signal.signal(signal.SIGINT, handler_done)
+    signal.signal(signal.SIGTERM, handler_done)
 
-    sig1 = dev.add_signal(mpr.Direction.INCOMING, "velocity_3d", 3,
-                        mpr.Type.FLOAT, "m/s", -9.9, 9.9, None)
-    sig2 = dev.add_signal(mpr.Direction.OUTGOING, "rgb_brightness", 3,
-                        mpr.Type.INT32, "lumens", 0, 255, None)
-    sig2.reserve_instances(4)
+    dev1 = mpr.Device("dev1")
+    sig2 = dev1.add_signal(mpr.Direction.OUTGOING, "out1", 3,
+                           mpr.Type.INT32, "lumens", 0, 255, None)
+
+    dev2 = mpr.Device("dev2")
+    sig1 = dev2.add_signal(mpr.Direction.INCOMING, "drywet", 3,
+                           mpr.Type.FLOAT, "m/s", -9.9, 9.9, None)
     
-    while(True):
-        dev.poll(100)
+    while(not done):
+        dev1.poll(100)
+        dev2.poll(100)
+
+    dev1.free()
+    dev2.free()

--- a/tests/test_session.json
+++ b/tests/test_session.json
@@ -1,5 +1,5 @@
 {
-    "fileversion": "2.3",
+    "fileversion": "2.4",
     "description": "A simple test session",
     "values": [],
     "views": [],


### PR DESCRIPTION
1. some internal changes for (IMO) better semantics: e.g. "stage/staging" was used when "wait/waiting" was meant
2. added optional `graph` argument for use with programs that have pre-synced graphs available (such as webmapper).
3. added `unload()` function/command, using session tags for now but could be developed into something more sophisticated in the future
4. made interactive session management work in parallel as we discussed earlier. Each session gets it's own control signal to keep semantic match (file name==signal name) and can be loaded/unloaded independently
5. separated 'waiting for signals' from 'persistently recreating maps'
6. re-added device wildcard when matching signals as was used in webmapper (and mapperGUI) previously. An optional `device_map` argument can be used for specific matches, otherwise `find_sigs()` will return a list of matching signals and maps will be created between each matching combination of signals (using `itertools.product()` internally).
7. a few other small fixes here and there 